### PR TITLE
feat: add standalone support for Redis and Valkey, including connection methods and load test commands

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,6 +31,30 @@ jobs:
       attestations: write
       id-token: write
 
+  e2etest-redis-standalone:
+    uses: ./.github/workflows/e2etest.yaml
+    with:
+      cache-platform: 'redis'
+      cache-mode: 'standalone'
+      cache-port: 6379
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+
+  e2etest-valkey-standalone:
+    uses: ./.github/workflows/e2etest.yaml
+    with:
+      cache-platform: 'valkey'
+      cache-mode: 'standalone'
+      cache-port: 6379
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+
   unittest:
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -37,6 +37,11 @@ on:
         type: number
         default: 30
         description: 'duration of the load test'
+      cache-mode:
+        required: false
+        type: string
+        default: 'cluster'
+        description: 'cluster or standalone'
 
 jobs:
   e2etest-cache:
@@ -104,8 +109,8 @@ jobs:
             otel/opentelemetry-collector:latest
           sleep 5
 
-      - name: Run E2E test for Redis
-        if: ${{ inputs.cache-platform == 'redis' }}
+      - name: Run E2E test for Redis (cluster)
+        if: ${{ inputs.cache-platform == 'redis' && inputs.cache-mode == 'cluster' }}
         run: |
           docker-compose -f docker-compose-${{ inputs.cache-platform }}.yml up -d && \
           sleep 60 && \
@@ -127,8 +132,8 @@ jobs:
             --otel-tracing-enabled true \
             --otel-exporter-endpoint http://localhost:4317
 
-      - name: Run E2E test for Valkey
-        if: ${{ inputs.cache-platform == 'valkey' }}
+      - name: Run E2E test for Valkey (cluster)
+        if: ${{ inputs.cache-platform == 'valkey' && inputs.cache-mode == 'cluster' }}
         run: |
           docker-compose -f docker-compose-${{ inputs.cache-platform }}.yml up -d
           echo "Waiting for Valkey cluster initialization..."
@@ -154,6 +159,52 @@ jobs:
             --otel-tracing-enabled true \
             --otel-exporter-endpoint http://localhost:4317
 
+      - name: Run E2E test for Redis (standalone)
+        if: ${{ inputs.cache-platform == 'redis' && inputs.cache-mode == 'standalone' }}
+        run: |
+          docker-compose -f docker-compose-redis-standalone.yml up -d && \
+          sleep 10 && \
+          poetry run locust_cache_benchmark init \
+            redis-standalone \
+            -f ${{ inputs.cache-host }} \
+            -p ${{ inputs.cache-port }} \
+            --ssl ${{ inputs.cache-ssl }} \
+            --otel-tracing-enabled true \
+            --otel-exporter-endpoint http://localhost:4317 && \
+          poetry run locust_cache_benchmark loadtest local \
+            redis-standalone \
+            -f ${{ inputs.cache-host }} \
+            -p ${{ inputs.cache-port }} \
+            -r ${{ inputs.cache-hit-rate }} \
+            -d ${{ inputs.loadtest-duration }} \
+            -c 1 -n 1 -k 1 -t 60 \
+            --ssl ${{ inputs.cache-ssl }} \
+            --otel-tracing-enabled true \
+            --otel-exporter-endpoint http://localhost:4317
+
+      - name: Run E2E test for Valkey (standalone)
+        if: ${{ inputs.cache-platform == 'valkey' && inputs.cache-mode == 'standalone' }}
+        run: |
+          docker-compose -f docker-compose-valkey-standalone.yml up -d && \
+          sleep 10 && \
+          poetry run locust_cache_benchmark init \
+            valkey-standalone \
+            -f ${{ inputs.cache-host }} \
+            -p ${{ inputs.cache-port }} \
+            --ssl ${{ inputs.cache-ssl }} \
+            --otel-tracing-enabled true \
+            --otel-exporter-endpoint http://localhost:4317 && \
+          poetry run locust_cache_benchmark loadtest local \
+            valkey-standalone \
+            -f ${{ inputs.cache-host }} \
+            -p ${{ inputs.cache-port }} \
+            -r ${{ inputs.cache-hit-rate }} \
+            -d ${{ inputs.loadtest-duration }} \
+            -c 1 -n 1 -k 1 -t 60 \
+            --ssl ${{ inputs.cache-ssl }} \
+            --otel-tracing-enabled true \
+            --otel-exporter-endpoint http://localhost:4317
+
       - name: Verify OTel spans were exported
         run: |
           SPAN_COUNT=$(docker logs otel-collector 2>&1 | grep -c "Span #" || true)
@@ -168,5 +219,5 @@ jobs:
       - name: output test result upload
         uses: actions/upload-artifact@v4
         with:
-          name: e2etest-${{ inputs.cache-platform }}
+          name: e2etest-${{ inputs.cache-platform }}-${{ inputs.cache-mode }}
           path: redis_test_results.csv

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ deployments.
 ## Supported Environments
 
 - [Redis](https://redis.io/) Cluster
+- [Redis](https://redis.io/) Standalone
 - [Valkey](https://valkey.io/) Cluster
+- [Valkey](https://valkey.io/) Standalone
 
 The above cache service is supported.
 
@@ -135,14 +137,20 @@ docker pull ghcr.io/s-mishina/locust-redis-benchmark:latest
 
 This tool provides the following subcommands:
 
-| Command                   | Description                                           |
-| ------------------------- | ----------------------------------------------------- |
-| `init redis`              | Initialize Redis cluster with test keys               |
-| `init valkey`             | Initialize Valkey cluster with test keys              |
-| `loadtest local redis`    | Run a local load test on Redis                        |
-| `loadtest local valkey`   | Run a local load test on Valkey                       |
-| `loadtest cluster redis`  | Run a distributed (master/worker) load test on Redis  |
-| `loadtest cluster valkey` | Run a distributed (master/worker) load test on Valkey |
+| Command                              | Description                                                      |
+| ------------------------------------ | ---------------------------------------------------------------- |
+| `init redis`                         | Initialize Redis cluster with test keys                          |
+| `init valkey`                        | Initialize Valkey cluster with test keys                         |
+| `init redis-standalone`              | Initialize standalone Redis with test keys                       |
+| `init valkey-standalone`             | Initialize standalone Valkey with test keys                      |
+| `loadtest local redis`               | Run a local load test on Redis cluster                           |
+| `loadtest local valkey`              | Run a local load test on Valkey cluster                          |
+| `loadtest local redis-standalone`    | Run a local load test on standalone Redis                        |
+| `loadtest local valkey-standalone`   | Run a local load test on standalone Valkey                       |
+| `loadtest cluster redis`             | Run a distributed (master/worker) load test on Redis cluster     |
+| `loadtest cluster valkey`            | Run a distributed (master/worker) load test on Valkey cluster    |
+| `loadtest cluster redis-standalone`  | Run a distributed (master/worker) load test on standalone Redis  |
+| `loadtest cluster valkey-standalone` | Run a distributed (master/worker) load test on standalone Valkey |
 
 ### Local Machine
 
@@ -157,6 +165,42 @@ To execute a local load test on a Redis cluster:
 
 ```sh
 locust_cache_benchmark loadtest local redis \
+  -f <hostname> -p <port> \
+  -r <hit_rate> -d <duration> \
+  -c <connections> -n <spawn_rate> \
+  -k <value_size> -t <ttl> \
+  -rr <request_rate>
+```
+
+To initialize a standalone Redis:
+
+```sh
+locust_cache_benchmark init redis-standalone \
+  -f <hostname> -p <port>
+```
+
+To initialize a standalone Valkey:
+
+```sh
+locust_cache_benchmark init valkey-standalone \
+  -f <hostname> -p <port>
+```
+
+To execute a local load test on a standalone Redis:
+
+```sh
+locust_cache_benchmark loadtest local redis-standalone \
+  -f <hostname> -p <port> \
+  -r <hit_rate> -d <duration> \
+  -c <connections> -n <spawn_rate> \
+  -k <value_size> -t <ttl> \
+  -rr <request_rate>
+```
+
+To execute a local load test on a standalone Valkey:
+
+```sh
+locust_cache_benchmark loadtest local valkey-standalone \
   -f <hostname> -p <port> \
   -r <hit_rate> -d <duration> \
   -c <connections> -n <spawn_rate> \
@@ -189,6 +233,31 @@ locust_cache_benchmark loadtest cluster redis \
   --master-bind-port 5557
 ```
 
+To execute a distributed load test on standalone Redis (master):
+
+```sh
+locust_cache_benchmark loadtest cluster redis-standalone \
+  -f <hostname> -p <port> \
+  -r <hit_rate> -d <duration> \
+  -c <connections> -n <spawn_rate> \
+  -k <value_size> -t <ttl> \
+  -rr <request_rate> \
+  --cluster-mode master \
+  --master-bind-host 0.0.0.0 \
+  --master-bind-port 5557 \
+  --num-workers 3
+```
+
+To execute a distributed load test on standalone Redis (worker):
+
+```sh
+locust_cache_benchmark loadtest cluster redis-standalone \
+  -f <hostname> -p <port> \
+  --cluster-mode worker \
+  --master-bind-host <master_host> \
+  --master-bind-port 5557
+```
+
 ### Container Usage
 
 To initialize a Redis cluster:
@@ -206,6 +275,28 @@ To execute a load test on a Redis cluster:
 docker run --rm -it \
   ghcr.io/s-mishina/locust-redis-benchmark:latest \
   locust_cache_benchmark loadtest local redis \
+  -f <hostname> -p <port> \
+  -r <hit_rate> -d <duration> \
+  -c <connections> -n <spawn_rate> \
+  -k <value_size> -t <ttl> \
+  -rr <request_rate>
+```
+
+To initialize a standalone Redis via container:
+
+```sh
+docker run --rm -it \
+  ghcr.io/s-mishina/locust-redis-benchmark:latest \
+  locust_cache_benchmark init redis-standalone \
+  -f <hostname> -p <port>
+```
+
+To execute a load test on a standalone Redis via container:
+
+```sh
+docker run --rm -it \
+  ghcr.io/s-mishina/locust-redis-benchmark:latest \
+  locust_cache_benchmark loadtest local redis-standalone \
   -f <hostname> -p <port> \
   -r <hit_rate> -d <duration> \
   -c <connections> -n <spawn_rate> \

--- a/cache_benchmark/src/cache_benchmark/locust_cache.py
+++ b/cache_benchmark/src/cache_benchmark/locust_cache.py
@@ -11,13 +11,13 @@ _RETRYABLE_EXCEPTIONS = (TimeoutError, ConnectionError, ClusterDownError)
 
 def _get_request_type():
     cache_type = os.environ.get("CACHE_TYPE", "redis_cluster")
-    if cache_type == "valkey_cluster":
+    if cache_type in ("valkey_cluster", "valkey"):
         return "Valkey"
     return "Redis"
 
 def _get_db_system():
     cache_type = os.environ.get("CACHE_TYPE", "redis_cluster")
-    if cache_type == "valkey_cluster":
+    if cache_type in ("valkey_cluster", "valkey"):
         return "valkey"
     return "redis"
 

--- a/cache_benchmark/src/cache_benchmark/main.py
+++ b/cache_benchmark/src/cache_benchmark/main.py
@@ -64,6 +64,92 @@ def cluster_valkey_load_test(args):
         logger.error("Please provide the --cluster-mode. master or worker")
         sys.exit(1)
 
+def redis_standalone_load_test(args):
+    set_env_vars(args)
+    set_env_cache_retry(args)
+    os.environ["CACHE_TYPE"] = "redis"
+    locust_runner_cash_benchmark(args,RedisUser)
+
+def valkey_standalone_load_test(args):
+    set_env_vars(args)
+    set_env_cache_retry(args)
+    os.environ["CACHE_TYPE"] = "valkey"
+    locust_runner_cash_benchmark(args,RedisUser)
+
+def cluster_redis_standalone_load_test(args):
+    if args.cluster_mode is None:
+        logger.error("Cluster mode not provided.")
+        logger.error("Please provide the --cluster-mode. master or worker")
+        sys.exit(1)
+    if args.cluster_mode == "master":
+        set_env_vars(args)
+        set_env_cache_retry(args)
+        os.environ["CACHE_TYPE"] = "redis"
+        locust_master_runner_benchmark(args,RedisUser)
+    elif args.cluster_mode == "worker":
+        set_env_vars(args)
+        set_env_cache_retry(args)
+        os.environ["CACHE_TYPE"] = "redis"
+        locust_worker_runner_benchmark(args,RedisUser)
+    else:
+        logger.error("Invalid cluster mode provided.")
+        logger.error("Please provide the --cluster-mode. master or worker")
+        sys.exit(1)
+
+def cluster_valkey_standalone_load_test(args):
+    if args.cluster_mode is None:
+        logger.error("Cluster mode not provided.")
+        logger.error("Please provide the --cluster-mode. master or worker")
+        sys.exit(1)
+    if args.cluster_mode == "master":
+        set_env_vars(args)
+        set_env_cache_retry(args)
+        os.environ["CACHE_TYPE"] = "valkey"
+        locust_master_runner_benchmark(args,RedisUser)
+    elif args.cluster_mode == "worker":
+        set_env_vars(args)
+        set_env_cache_retry(args)
+        os.environ["CACHE_TYPE"] = "valkey"
+        locust_worker_runner_benchmark(args,RedisUser)
+    else:
+        logger.error("Invalid cluster mode provided.")
+        logger.error("Please provide the --cluster-mode. master or worker")
+        sys.exit(1)
+
+def init_redis_standalone_load_test(args):
+    set_env_vars(args)
+    set_env_cache_retry(args)
+    setup_otel_tracing()
+    cache = CacheConnect()
+    cache_client = cache.redis_standalone_connect()
+    if cache_client is None:
+        logger.error("Redis standalone client initialization failed.")
+        sys.exit(1)
+    try:
+        value = generate_string(args.value_size)
+        init_cache_set(cache_client, value, int(os.environ["TTL"]), args.set_keys)
+    finally:
+        cache_client.close()
+        logger.info("Redis standalone connection closed after init.")
+        shutdown_otel_tracing()
+
+def init_valkey_standalone_load_test(args):
+    set_env_vars(args)
+    set_env_cache_retry(args)
+    setup_otel_tracing()
+    cache = CacheConnect()
+    cache_client = cache.valkey_standalone_connect()
+    if cache_client is None:
+        logger.error("Valkey standalone client initialization failed.")
+        sys.exit(1)
+    try:
+        value = generate_string(args.value_size)
+        init_cache_set(cache_client, value, int(os.environ["TTL"]), args.set_keys)
+    finally:
+        cache_client.close()
+        logger.info("Valkey standalone connection closed after init.")
+        shutdown_otel_tracing()
+
 def init_valkey_load_test(args):
     set_env_vars(args)
     set_env_cache_retry(args)
@@ -117,6 +203,14 @@ def main():
     local_valkey_parser = local_subparsers.add_parser("valkey", help="Run load test on Valkey locally")
     add_common_arguments(local_valkey_parser)
     local_valkey_parser.set_defaults(func=valkey_load_test)
+    # loadtest local redis-standalone subcommand
+    local_redis_standalone_parser = local_subparsers.add_parser("redis-standalone", help="Run load test on standalone Redis locally")
+    add_common_arguments(local_redis_standalone_parser)
+    local_redis_standalone_parser.set_defaults(func=redis_standalone_load_test)
+    # loadtest local valkey-standalone subcommand
+    local_valkey_standalone_parser = local_subparsers.add_parser("valkey-standalone", help="Run load test on standalone Valkey locally")
+    add_common_arguments(local_valkey_standalone_parser)
+    local_valkey_standalone_parser.set_defaults(func=valkey_standalone_load_test)
     # loadtest cluster subcommand
     local_parser = loadtest_subparsers.add_parser("cluster", help="Run locust Cluster test locally")
     local_subparsers = local_parser.add_subparsers(dest="subcommand")
@@ -128,6 +222,14 @@ def main():
     local_valkey_parser = local_subparsers.add_parser("valkey", help="Run Cluster test on Valkey locally")
     add_common_arguments(local_valkey_parser)
     local_valkey_parser.set_defaults(func=cluster_valkey_load_test)
+    # loadtest cluster redis-standalone subcommand
+    cluster_redis_standalone_parser = local_subparsers.add_parser("redis-standalone", help="Run Cluster test on standalone Redis")
+    add_common_arguments(cluster_redis_standalone_parser)
+    cluster_redis_standalone_parser.set_defaults(func=cluster_redis_standalone_load_test)
+    # loadtest cluster valkey-standalone subcommand
+    cluster_valkey_standalone_parser = local_subparsers.add_parser("valkey-standalone", help="Run Cluster test on standalone Valkey")
+    add_common_arguments(cluster_valkey_standalone_parser)
+    cluster_valkey_standalone_parser.set_defaults(func=cluster_valkey_standalone_load_test)
 
     # init subcommand
     init_parser = subparsers.add_parser("init", help="Initialization commands")
@@ -140,6 +242,14 @@ def main():
     init_valkey_parser = init_subparsers.add_parser("valkey", help="Initialize Valkey")
     add_common_arguments(init_valkey_parser)
     init_valkey_parser.set_defaults(func=init_valkey_load_test)
+    # init redis-standalone subcommand
+    init_redis_standalone_parser = init_subparsers.add_parser("redis-standalone", help="Initialize standalone Redis")
+    add_common_arguments(init_redis_standalone_parser)
+    init_redis_standalone_parser.set_defaults(func=init_redis_standalone_load_test)
+    # init valkey-standalone subcommand
+    init_valkey_standalone_parser = init_subparsers.add_parser("valkey-standalone", help="Initialize standalone Valkey")
+    add_common_arguments(init_valkey_standalone_parser)
+    init_valkey_standalone_parser.set_defaults(func=init_valkey_standalone_load_test)
 
     args = parser.parse_args()
     if args.command and args.subcommand:

--- a/cache_benchmark/src/cache_benchmark/scenario.py
+++ b/cache_benchmark/src/cache_benchmark/scenario.py
@@ -73,6 +73,10 @@ class RedisUser(User):
                     cls._shared_cache_conn = cache.redis_connect()
                 elif cache_type == "valkey_cluster":
                     cls._shared_cache_conn = cache.valkey_connect()
+                elif cache_type == "redis":
+                    cls._shared_cache_conn = cache.redis_standalone_connect()
+                elif cache_type == "valkey":
+                    cls._shared_cache_conn = cache.valkey_standalone_connect()
             cls._shared_conn_users += 1
             return cls._shared_cache_conn
 

--- a/cache_benchmark/tests/test_cash_connect.py
+++ b/cache_benchmark/tests/test_cash_connect.py
@@ -13,6 +13,7 @@ class TestCashConnect(unittest.TestCase):
         os.environ["REDIS_HOST"] = "localhost"
         os.environ["REDIS_PORT"] = "6379"
         os.environ["CONNECTIONS_POOL"] = "10"
+        os.environ["SSL"] = "false"
 
     def tearDown(self):
         os.environ.clear()
@@ -65,4 +66,62 @@ class TestCashConnect(unittest.TestCase):
     def test_valkey_connect_unexpected_error(self):
         with patch("valkey.cluster.ValkeyCluster", side_effect=Exception):
             conn = CacheConnect.valkey_connect(self)
+            self.assertIsNone(conn)
+
+    def test_redis_standalone_connect_success(self):
+        with patch("cache_benchmark.cash_connect.Redis") as mock_redis:
+            mock_conn = Mock()
+            mock_redis.return_value = mock_conn
+            conn = CacheConnect.redis_standalone_connect(self)
+            self.assertIsNotNone(conn)
+            mock_conn.ping.assert_called_once()
+
+    def test_redis_standalone_connect_missing_env_vars(self):
+        self.tearDown()
+        conn = CacheConnect.redis_standalone_connect(self)
+        self.assertIsNone(conn)
+
+    def test_redis_standalone_connect_timeout_error(self):
+        with patch("cache_benchmark.cash_connect.Redis") as mock_redis:
+            mock_conn = Mock()
+            mock_conn.ping.side_effect = TimeoutError
+            mock_redis.return_value = mock_conn
+            conn = CacheConnect.redis_standalone_connect(self)
+            self.assertIsNone(conn)
+
+    def test_redis_standalone_connect_connection_error(self):
+        with patch("cache_benchmark.cash_connect.Redis") as mock_redis:
+            mock_conn = Mock()
+            mock_conn.ping.side_effect = ConnectionError
+            mock_redis.return_value = mock_conn
+            conn = CacheConnect.redis_standalone_connect(self)
+            self.assertIsNone(conn)
+
+    def test_valkey_standalone_connect_success(self):
+        with patch("cache_benchmark.cash_connect.Valkey") as mock_valkey:
+            mock_conn = Mock()
+            mock_valkey.return_value = mock_conn
+            conn = CacheConnect.valkey_standalone_connect(self)
+            self.assertIsNotNone(conn)
+            mock_conn.ping.assert_called_once()
+
+    def test_valkey_standalone_connect_missing_env_vars(self):
+        self.tearDown()
+        conn = CacheConnect.valkey_standalone_connect(self)
+        self.assertIsNone(conn)
+
+    def test_valkey_standalone_connect_timeout_error(self):
+        with patch("cache_benchmark.cash_connect.Valkey") as mock_valkey:
+            mock_conn = Mock()
+            mock_conn.ping.side_effect = ValkeyTimeoutError
+            mock_valkey.return_value = mock_conn
+            conn = CacheConnect.valkey_standalone_connect(self)
+            self.assertIsNone(conn)
+
+    def test_valkey_standalone_connect_connection_error(self):
+        with patch("cache_benchmark.cash_connect.Valkey") as mock_valkey:
+            mock_conn = Mock()
+            mock_conn.ping.side_effect = ValkeyConnectionError
+            mock_valkey.return_value = mock_conn
+            conn = CacheConnect.valkey_standalone_connect(self)
             self.assertIsNone(conn)

--- a/cache_benchmark/tests/test_main.py
+++ b/cache_benchmark/tests/test_main.py
@@ -1,7 +1,12 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import sys
-from cache_benchmark.main import main, redis_load_test, valkey_load_test, init_redis_load_test, init_valkey_load_test, cluster_valkey_load_test
+from cache_benchmark.main import (
+    main, redis_load_test, valkey_load_test, init_redis_load_test, init_valkey_load_test, cluster_valkey_load_test,
+    redis_standalone_load_test, valkey_standalone_load_test,
+    cluster_redis_standalone_load_test, cluster_valkey_standalone_load_test,
+    init_redis_standalone_load_test, init_valkey_standalone_load_test,
+)
 from cache_benchmark.scenario import RedisUser
 
 class TestMain(unittest.TestCase):
@@ -90,6 +95,120 @@ class TestMain(unittest.TestCase):
         args.cluster_mode = None
         cluster_valkey_load_test(args)
         mock_exit.assert_called_with(1)
+
+    @patch('cache_benchmark.main.set_env_cache_retry')
+    @patch('cache_benchmark.main.set_env_vars')
+    @patch('cache_benchmark.main.locust_runner_cash_benchmark')
+    def test_redis_standalone_load_test(self, mock_locust_runner, mock_set_env_vars, mock_set_env_cache_retry):
+        args = MagicMock()
+        redis_standalone_load_test(args)
+        mock_set_env_vars.assert_called_once_with(args)
+        mock_set_env_cache_retry.assert_called_once_with(args)
+        mock_locust_runner.assert_called_once_with(args, RedisUser)
+
+    @patch('cache_benchmark.main.set_env_cache_retry')
+    @patch('cache_benchmark.main.set_env_vars')
+    @patch('cache_benchmark.main.locust_runner_cash_benchmark')
+    def test_valkey_standalone_load_test(self, mock_locust_runner, mock_set_env_vars, mock_set_env_cache_retry):
+        args = MagicMock()
+        valkey_standalone_load_test(args)
+        mock_set_env_vars.assert_called_once_with(args)
+        mock_set_env_cache_retry.assert_called_once_with(args)
+        mock_locust_runner.assert_called_once_with(args, RedisUser)
+
+    @patch('cache_benchmark.main.set_env_cache_retry')
+    @patch('cache_benchmark.main.set_env_vars')
+    @patch('cache_benchmark.main.locust_master_runner_benchmark')
+    def test_cluster_redis_standalone_load_test_master(self, mock_master_runner, mock_set_env_vars, mock_set_env_cache_retry):
+        args = MagicMock()
+        args.cluster_mode = "master"
+        cluster_redis_standalone_load_test(args)
+        mock_set_env_vars.assert_called_once_with(args)
+        mock_set_env_cache_retry.assert_called_once_with(args)
+        mock_master_runner.assert_called_once_with(args, RedisUser)
+
+    @patch('cache_benchmark.main.set_env_cache_retry')
+    @patch('cache_benchmark.main.set_env_vars')
+    @patch('cache_benchmark.main.locust_worker_runner_benchmark')
+    def test_cluster_redis_standalone_load_test_worker(self, mock_worker_runner, mock_set_env_vars, mock_set_env_cache_retry):
+        args = MagicMock()
+        args.cluster_mode = "worker"
+        cluster_redis_standalone_load_test(args)
+        mock_set_env_vars.assert_called_once_with(args)
+        mock_set_env_cache_retry.assert_called_once_with(args)
+        mock_worker_runner.assert_called_once_with(args, RedisUser)
+
+    @patch('cache_benchmark.main.sys.exit')
+    def test_cluster_redis_standalone_load_test_no_mode(self, mock_exit):
+        args = MagicMock()
+        args.cluster_mode = None
+        cluster_redis_standalone_load_test(args)
+        mock_exit.assert_called_with(1)
+
+    @patch('cache_benchmark.main.set_env_cache_retry')
+    @patch('cache_benchmark.main.set_env_vars')
+    @patch('cache_benchmark.main.locust_master_runner_benchmark')
+    def test_cluster_valkey_standalone_load_test_master(self, mock_master_runner, mock_set_env_vars, mock_set_env_cache_retry):
+        args = MagicMock()
+        args.cluster_mode = "master"
+        cluster_valkey_standalone_load_test(args)
+        mock_set_env_vars.assert_called_once_with(args)
+        mock_set_env_cache_retry.assert_called_once_with(args)
+        mock_master_runner.assert_called_once_with(args, RedisUser)
+
+    @patch('cache_benchmark.main.set_env_cache_retry')
+    @patch('cache_benchmark.main.set_env_vars')
+    @patch('cache_benchmark.main.locust_worker_runner_benchmark')
+    def test_cluster_valkey_standalone_load_test_worker(self, mock_worker_runner, mock_set_env_vars, mock_set_env_cache_retry):
+        args = MagicMock()
+        args.cluster_mode = "worker"
+        cluster_valkey_standalone_load_test(args)
+        mock_set_env_vars.assert_called_once_with(args)
+        mock_set_env_cache_retry.assert_called_once_with(args)
+        mock_worker_runner.assert_called_once_with(args, RedisUser)
+
+    @patch('cache_benchmark.main.sys.exit')
+    def test_cluster_valkey_standalone_load_test_no_mode(self, mock_exit):
+        args = MagicMock()
+        args.cluster_mode = None
+        cluster_valkey_standalone_load_test(args)
+        mock_exit.assert_called_with(1)
+
+    @patch('cache_benchmark.main.set_env_cache_retry')
+    @patch('cache_benchmark.main.set_env_vars')
+    @patch('cache_benchmark.main.CacheConnect.redis_standalone_connect')
+    @patch('cache_benchmark.main.generate_string')
+    @patch('cache_benchmark.main.init_cache_set')
+    @patch.dict('os.environ', {'TTL': '60'})
+    def test_init_redis_standalone_load_test_success(self, mock_init_cache_set, mock_generate_string, mock_redis_standalone_connect, mock_set_env_vars, mock_set_env_cache_retry):
+        args = MagicMock()
+        args.set_keys = 1000
+        mock_redis_standalone_connect.return_value = MagicMock()
+        mock_generate_string.return_value = "test_value"
+        init_redis_standalone_load_test(args)
+        mock_set_env_vars.assert_called_once_with(args)
+        mock_set_env_cache_retry.assert_called_once_with(args)
+        mock_redis_standalone_connect.assert_called_once()
+        mock_generate_string.assert_called_once_with(args.value_size)
+        mock_init_cache_set.assert_called_once_with(mock_redis_standalone_connect.return_value, "test_value", 60, 1000)
+
+    @patch('cache_benchmark.main.set_env_cache_retry')
+    @patch('cache_benchmark.main.set_env_vars')
+    @patch('cache_benchmark.main.CacheConnect.valkey_standalone_connect')
+    @patch('cache_benchmark.main.generate_string')
+    @patch('cache_benchmark.main.init_cache_set')
+    @patch.dict('os.environ', {'TTL': '60'})
+    def test_init_valkey_standalone_load_test_success(self, mock_init_cache_set, mock_generate_string, mock_valkey_standalone_connect, mock_set_env_vars, mock_set_env_cache_retry):
+        args = MagicMock()
+        args.set_keys = 500
+        mock_valkey_standalone_connect.return_value = MagicMock()
+        mock_generate_string.return_value = "test_value"
+        init_valkey_standalone_load_test(args)
+        mock_set_env_vars.assert_called_once_with(args)
+        mock_set_env_cache_retry.assert_called_once_with(args)
+        mock_valkey_standalone_connect.assert_called_once()
+        mock_generate_string.assert_called_once_with(args.value_size)
+        mock_init_cache_set.assert_called_once_with(mock_valkey_standalone_connect.return_value, "test_value", 60, 500)
 
     @patch('argparse.ArgumentParser.parse_args')
     @patch('cache_benchmark.main.sys.exit')

--- a/docker-compose-redis-standalone.yml
+++ b/docker-compose-redis-standalone.yml
@@ -1,0 +1,6 @@
+services:
+  redis-standalone:
+    image: redis:6
+    ports:
+      - "6379:6379"
+    restart: "no"

--- a/docker-compose-valkey-standalone.yml
+++ b/docker-compose-valkey-standalone.yml
@@ -1,0 +1,6 @@
+services:
+  valkey-standalone:
+    image: valkey/valkey:latest
+    ports:
+      - "6379:6379"
+    restart: "no"


### PR DESCRIPTION
This pull request adds comprehensive support for running benchmarks against standalone Redis and Valkey instances, in addition to the existing cluster modes. The changes include updates to the benchmarking tool's codebase, enhancements to the GitHub Actions CI workflows, and expanded documentation to guide users in running and initializing tests for both standalone and cluster deployments.

**Standalone Redis and Valkey Support**

- Added new connection methods for standalone Redis and Valkey in `cash_connect.py`, enabling the tool to connect and benchmark single-node instances. [[1]](diffhunk://#diff-1a227aefbcc3f80f6ff8bf70972e1c2ef0e207b32a467f0935d3f1be563b3775R1-R4) [[2]](diffhunk://#diff-1a227aefbcc3f80f6ff8bf70972e1c2ef0e207b32a467f0935d3f1be563b3775R77-R121) [[3]](diffhunk://#diff-1a227aefbcc3f80f6ff8bf70972e1c2ef0e207b32a467f0935d3f1be563b3775R175-R219)
- Implemented new CLI subcommands and logic in `main.py` to initialize and run both local and distributed (cluster) load tests on standalone Redis and Valkey, mirroring the existing cluster functionality. [[1]](diffhunk://#diff-257890b8aee81cb73e8e6a80737d8239c100da63dba739e19bba8db6bddd21c6R67-R152) [[2]](diffhunk://#diff-257890b8aee81cb73e8e6a80737d8239c100da63dba739e19bba8db6bddd21c6R206-R213) [[3]](diffhunk://#diff-257890b8aee81cb73e8e6a80737d8239c100da63dba739e19bba8db6bddd21c6R225-R232)

**CI/CD Workflow Enhancements**

- Updated `.github/workflows/e2etest.yaml` and `.github/workflows/deploy.yaml` to add jobs and logic for running end-to-end tests against standalone Redis and Valkey, including support for selecting cache mode (cluster or standalone) and using appropriate Docker Compose files. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R34-R57) [[2]](diffhunk://#diff-3f655f49e4dabda95d4221557249f46195bcf4d9fe164a31f7ff7d988032c20dR40-R44) [[3]](diffhunk://#diff-3f655f49e4dabda95d4221557249f46195bcf4d9fe164a31f7ff7d988032c20dL107-R113) [[4]](diffhunk://#diff-3f655f49e4dabda95d4221557249f46195bcf4d9fe164a31f7ff7d988032c20dL130-R136) [[5]](diffhunk://#diff-3f655f49e4dabda95d4221557249f46195bcf4d9fe164a31f7ff7d988032c20dR162-R207) [[6]](diffhunk://#diff-3f655f49e4dabda95d4221557249f46195bcf4d9fe164a31f7ff7d988032c20dL171-R222)

**Documentation Updates**

- Expanded the `README.md` to document new commands and usage examples for initializing and running load tests on standalone Redis and Valkey, both locally and in containers, as well as in distributed (cluster) mode. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R52) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L139-R153) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R175-R210) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R260) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R285-R306)

**Minor Improvements**

- Adjusted type detection logic in `locust_cache.py` to recognize both `"valkey_cluster"` and `"valkey"` as valid Valkey types.

These changes make the benchmarking tool more flexible and easier to use across a wider range of Redis and Valkey deployment scenarios.